### PR TITLE
Add Agno-based RAG UI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Playground
+
+This repository contains example applications for large language models (LLMs).
+
+## Contents
+
+- `examples/rag-truehorizon` – retrieval-augmented chatbot and Streamlit UI built with the Agno framework for content from [truehorizon.ai](https://truehorizon.ai).

--- a/examples/rag-truehorizon/README.md
+++ b/examples/rag-truehorizon/README.md
@@ -1,0 +1,31 @@
+# TrueHorizon AI RAG Example
+
+This folder contains a simple retrieval-augmented generation (RAG) chatbot setup for TrueHorizon AI. The dataset is built from pages scraped from [truehorizon.ai](https://truehorizon.ai). The crawler automatically discovers all pages under the site.
+
+## Setup
+
+1. Install Python packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run `ingest.py` to crawl the website and build an index (this only needs to be done when the site content changes):
+
+```bash
+python ingest.py
+```
+
+3. Start the command line chat application:
+
+```bash
+python chat.py
+```
+
+4. Alternatively, launch a small web UI:
+
+```bash
+streamlit run app.py
+```
+
+The chatbot loads the pre-built index and answers questions about TrueHorizon AI without re-ingesting the site on each run.

--- a/examples/rag-truehorizon/app.py
+++ b/examples/rag-truehorizon/app.py
@@ -1,0 +1,56 @@
+"""Streamlit UI for chatting with the TrueHorizon AI knowledge base."""
+
+import pickle
+import numpy as np
+import faiss
+import openai
+import streamlit as st
+from agno import Agent
+
+INDEX_PATH = "faiss_index.pkl"
+
+
+def embed_text(text: str) -> list:
+    result = openai.Embedding.create(model="text-embedding-ada-002", input=[text])
+    return result["data"][0]["embedding"]
+
+
+def load_index():
+    with open(INDEX_PATH, "rb") as f:
+        data = pickle.load(f)
+    return data["index"], data["texts"]
+
+
+class RAGAgent(Agent):
+    def __init__(self, index, texts):
+        super().__init__()
+        self.index = index
+        self.texts = texts
+
+    def run(self, query: str) -> str:
+        vector = np.array([embed_text(query)], dtype="float32")
+        _, idxs = self.index.search(vector, k=3)
+        context = "\n".join(self.texts[i] for i in idxs[0])
+        prompt = (
+            "Answer the user question using the following website content:\n" + context
+        )
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt + "\n\n" + query}],
+        )
+        return response["choices"][0]["message"]["content"].strip()
+
+
+def main():
+    index, texts = load_index()
+    agent = RAGAgent(index, texts)
+
+    st.title("TrueHorizon AI Chatbot")
+    query = st.text_input("Ask a question about TrueHorizon AI")
+    if query:
+        answer = agent.run(query)
+        st.write(answer)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rag-truehorizon/chat.py
+++ b/examples/rag-truehorizon/chat.py
@@ -1,0 +1,62 @@
+"""Command line chat with TrueHorizon AI knowledge base using Agno."""
+
+import pickle
+import openai
+import numpy as np
+import faiss
+from agno import Agent
+
+INDEX_PATH = "faiss_index.pkl"
+
+
+def embed_text(text: str) -> list:
+    """Return an embedding vector for the given text."""
+    result = openai.Embedding.create(model="text-embedding-ada-002", input=[text])
+    return result["data"][0]["embedding"]
+
+
+def load_index():
+    with open(INDEX_PATH, "rb") as f:
+        data = pickle.load(f)
+    return data["index"], data["texts"]
+
+
+class RAGAgent(Agent):
+    """Simple retrieval-augmented agent."""
+
+    def __init__(self, index, texts):
+        super().__init__()
+        self.index = index
+        self.texts = texts
+
+    def run(self, query: str) -> str:
+        vector = np.array([embed_text(query)], dtype="float32")
+        _, idxs = self.index.search(vector, k=3)
+        context = "\n".join(self.texts[i] for i in idxs[0])
+        prompt = (
+            "Answer the user question using the following website content:\n" + context
+        )
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt + "\n\n" + query}],
+        )
+        return response["choices"][0]["message"]["content"].strip()
+
+
+def main():
+    index, texts = load_index()
+    agent = RAGAgent(index, texts)
+    print("Ask me anything about TrueHorizon AI (Ctrl+C to exit)")
+    while True:
+        try:
+            question = input("Question: ")
+        except (EOFError, KeyboardInterrupt):
+            break
+        if not question:
+            continue
+        answer = agent.run(question)
+        print("Answer:", answer)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rag-truehorizon/ingest.py
+++ b/examples/rag-truehorizon/ingest.py
@@ -1,0 +1,79 @@
+"""Crawl TrueHorizon AI pages and build a FAISS index."""
+
+import os
+import pickle
+import requests
+from urllib.parse import urljoin, urlparse
+from bs4 import BeautifulSoup
+import faiss
+import numpy as np
+import openai
+
+BASE_URL = "https://truehorizon.ai"
+
+DATA_DIR = "data"
+INDEX_PATH = "faiss_index.pkl"
+
+
+def fetch_page(url: str) -> str:
+    """Fetch a single page and return its text."""
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    return soup.get_text()
+
+
+def crawl_site(start_url: str) -> None:
+    """Crawl all pages under the given domain and save them to ``DATA_DIR``."""
+    seen = set()
+    queue = [start_url]
+    while queue:
+        url = queue.pop(0)
+        if url in seen:
+            continue
+        seen.add(url)
+        try:
+            text = fetch_page(url)
+        except Exception:
+            continue
+        path = urlparse(url).path.strip("/") or "index"
+        os.makedirs(DATA_DIR, exist_ok=True)
+        with open(os.path.join(DATA_DIR, f"{path}.txt"), "w", encoding="utf-8") as f:
+            f.write(text)
+        soup = BeautifulSoup(text, "html.parser")
+        for tag in soup.find_all("a", href=True):
+            link = tag["href"]
+            if link.startswith("http"):
+                full = link
+            else:
+                full = urljoin(start_url, link)
+            if full.startswith(start_url) and full not in seen:
+                queue.append(full)
+
+
+def embed_text(text: str) -> list:
+    """Return an embedding vector for the given text."""
+    result = openai.Embedding.create(model="text-embedding-ada-002", input=[text])
+    return result["data"][0]["embedding"]
+
+
+def build_index() -> None:
+    """Create a FAISS index from crawled pages."""
+    texts = []
+    for fname in os.listdir(DATA_DIR):
+        with open(os.path.join(DATA_DIR, fname), "r", encoding="utf-8") as f:
+            texts.append(f.read())
+
+    vectors = [embed_text(t) for t in texts]
+    dim = len(vectors[0])
+    index = faiss.IndexFlatL2(dim)
+    index.add(np.array(vectors).astype("float32"))
+
+    with open(INDEX_PATH, "wb") as f:
+        pickle.dump({"index": index, "texts": texts}, f)
+
+
+if __name__ == "__main__":
+    crawl_site(BASE_URL)
+    build_index()
+    print("Index built at", INDEX_PATH)

--- a/examples/rag-truehorizon/requirements.txt
+++ b/examples/rag-truehorizon/requirements.txt
@@ -1,0 +1,7 @@
+openai
+faiss-cpu
+beautifulsoup4
+requests
+streamlit
+numpy
+agno


### PR DESCRIPTION
## Summary
- rewrite ingest to crawl all subpages and store FAISS index
- replace LangChain chat script with Agno-based agent
- add a small Streamlit UI
- document setup and update requirements

## Testing
- `python -m py_compile examples/rag-truehorizon/*.py`
