### PR TITLE
fix: Resolve ImportError for agno.Agent

### DIFF
--- a/examples/rag-truehorizon/app.py
+++ b/examples/rag-truehorizon/app.py
@@ -5,7 +5,6 @@ import numpy as np
 import faiss
 import openai
 import streamlit as st
-from agno import Agent
 import os
 import whoosh.index as whoosh_index
 from whoosh.qparser import MultifieldParser
@@ -55,11 +54,10 @@ def load_indexes():
     return faiss_idx, texts, fnames, whoosh_ix
 
 
-class RAGAgent(Agent):
+class RAGAgent:
     """Retrieval-augmented agent using FAISS and Whoosh with Reciprocal Rank Fusion."""
 
     def __init__(self, faiss_idx, texts, fnames, whoosh_ix):
-        super().__init__()
         self.faiss_idx = faiss_idx
         self.texts = texts
         self.fnames = fnames

--- a/examples/rag-truehorizon/chat.py
+++ b/examples/rag-truehorizon/chat.py
@@ -4,7 +4,6 @@ import pickle
 import openai
 import numpy as np
 import faiss
-from agno import Agent
 import os
 import whoosh.index as whoosh_index
 from whoosh.qparser import QueryParser, MultifieldParser
@@ -62,11 +61,10 @@ def load_indexes():
     return faiss_idx, texts, fnames, whoosh_ix
 
 
-class RAGAgent(Agent):
+class RAGAgent:
     """Retrieval-augmented agent using FAISS and Whoosh with Reciprocal Rank Fusion."""
 
     def __init__(self, faiss_idx, texts, fnames, whoosh_ix):
-        super().__init__()
         self.faiss_idx = faiss_idx
         self.texts = texts
         self.fnames = fnames # Needed to map Whoosh results (path) to text index

--- a/examples/rag-truehorizon/requirements.txt
+++ b/examples/rag-truehorizon/requirements.txt
@@ -4,5 +4,4 @@ beautifulsoup4
 requests
 streamlit
 numpy
-agno
 whoosh


### PR DESCRIPTION
This commit fixes an `ImportError: cannot import name 'Agent' from 'agno'` by removing the dependency on the `agno` library.

The `RAGAgent` class in `chat.py` and `app.py` no longer inherits from `agno.Agent`, and the `agno` library has been removed from `requirements.txt`. This change was made because the `Agent` class was causing import errors, and it did not seem to provide critical functionality for the RAG pipeline's operation within the visible codebase.